### PR TITLE
Adjust sidebar height for iOS 26

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --vh: 1vh;
+}
+
 body {
   font-family: Arial, Helvetica, sans-serif;
   background-color: #264085;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,6 +45,7 @@ export const viewport: Viewport = {
     initialScale: 1,
     maximumScale: 5,
     userScalable: true,
+    viewportFit: "cover",
     themeColor: [
         { media: "(prefers-color-scheme: light)", color: "#3b82f6" },
         { media: "(prefers-color-scheme: dark)", color: "#1e40af" },

--- a/app/styles.css
+++ b/app/styles.css
@@ -14,6 +14,56 @@
     @apply text-white/80 glassmorphism bg-transparent transition duration-500 data-[state=open]:bg-blue-600/50
 }
 
+/* iOS Safari height fix utilities */
+.h-screen-ios {
+    height: calc(var(--vh, 1vh) * 100);
+}
+
+.min-h-screen-ios {
+    min-height: calc(var(--vh, 1vh) * 100);
+}
+
+/* Ensure sidebar takes full height on iOS */
+.sidebar-full-height {
+    height: calc(var(--vh, 1vh) * 100);
+    min-height: calc(var(--vh, 1vh) * 100);
+}
+
+/* Additional iOS Safari fixes */
+@supports (-webkit-touch-callout: none) {
+    .sidebar-full-height {
+        height: -webkit-fill-available;
+        min-height: -webkit-fill-available;
+    }
+    
+    .h-screen-ios {
+        height: -webkit-fill-available;
+    }
+    
+    .min-h-screen-ios {
+        min-height: -webkit-fill-available;
+    }
+}
+
+/* Ensure proper sidebar positioning */
+.sidebar-fixed {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 40;
+}
+
+/* Responsive sidebar adjustments */
+@media (max-width: 768px) {
+    .sidebar-fixed {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+    }
+}
+
 .description ol {
     list-style-type: decimal;
     padding-left: 20px;

--- a/components/main.tsx
+++ b/components/main.tsx
@@ -18,8 +18,8 @@ const Main = ({ children }: { children: React.ReactNode }) => {
                     isMobile || hide
                         ? "w-full"
                         : open
-                        ? "w-[calc(100%-13rem)]"
-                        : "w-[calc(100%-47px)]"
+                        ? "w-[calc(100%-13rem)] ml-52"
+                        : "w-[calc(100%-47px)] ml-12"
                 } ${hide ? "h-screen" : "h-full"}`}
             >
                 {children}

--- a/components/sidebar/user/index.tsx
+++ b/components/sidebar/user/index.tsx
@@ -21,11 +21,13 @@ import { ChevronDown } from "lucide-react"
 import { menus, useCollapsibleMenus } from "./menus"
 import { ScrollArea } from "../../ui/scroll-area"
 import { FeedbackDialog } from "../feedback-dialog"
+import { useDynamicViewportHeight } from "@/hooks/use-ios-height"
 
 export default function UserSidebar() {
     const pathname = usePathname()
     const { data: session } = useSession()
     const [feedbackOpen, setFeedbackOpen] = useState(false)
+    const sidebarHeight = useDynamicViewportHeight()
     const collapsibleMenus = useCollapsibleMenus()
 
     const filteredCollapsibleMenus = collapsibleMenus
@@ -52,13 +54,16 @@ export default function UserSidebar() {
     return (
         <>
             {hide ? null : (
-                <aside className='sticky top-0 self-start max-w-52 glassmorphism'>
+                <aside 
+                    className='sidebar-fixed w-52 glassmorphism sidebar-full-height'
+                    style={{ height: sidebarHeight }}
+                >
                     <Sidebar
-                        className='mt-[58px] w-52 border-white/20'
+                        className='w-52 border-white/20 h-full'
                         collapsible='icon'
                     >
-                        <SidebarContent>
-                            <ScrollArea className='pt-2 pb-20'>
+                        <SidebarContent className='h-full'>
+                            <ScrollArea className='pt-2 pb-20 h-full'>
                                 {/* Main menu */}
                                 <SidebarGroup>
                                     <SidebarGroupContent>

--- a/components/sidebar/user/mobile.tsx
+++ b/components/sidebar/user/mobile.tsx
@@ -21,6 +21,7 @@ import { ScrollArea } from "../../ui/scroll-area"
 import { Logo } from "../../logo"
 import { LoadingLink } from "../../loading-link"
 import { FeedbackDialog } from "../feedback-dialog"
+import { useDynamicViewportHeight } from "@/hooks/use-ios-height"
 
 const MobileSidebar = ({
     setOpen,
@@ -30,6 +31,7 @@ const MobileSidebar = ({
     const pathname = usePathname()
     const { data: session } = useSession()
     const [feedbackOpen, setFeedbackOpen] = useState(false)
+    const sidebarHeight = useDynamicViewportHeight()
     const collapsibleMenus = useCollapsibleMenus()
 
     const filteredCollapsibleMenus = collapsibleMenus
@@ -56,10 +58,11 @@ const MobileSidebar = ({
         <>
             <SheetContent
                 side='left'
-                className='w-[300px] sm:w-[400px] p-0 glassmorphism bg-blue-900/50 !rounded-none h-full border-0'
+                className='w-[300px] sm:w-[400px] p-0 glassmorphism bg-blue-900/50 !rounded-none border-0 sidebar-full-height'
+                style={{ height: sidebarHeight }}
             >
                 <Logo className='text-2xl absolute top-8 w-fit ml-10' />
-                <div className='w-full h-3/4 mt-20 relative'>
+                <div className='w-full h-full mt-20 relative'>
                     <ScrollArea className='w-full h-full flex flex-col justify-center items-center'>
                         <SheetHeader className='hidden'>
                             <SheetTitle>BlueBizHub</SheetTitle>

--- a/hooks/use-ios-height.ts
+++ b/hooks/use-ios-height.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react'
+
+export function useIOSHeight() {
+    const [height, setHeight] = useState('100vh')
+
+    useEffect(() => {
+        const updateHeight = () => {
+            // Use dynamic viewport height for better iOS support
+            const vh = window.innerHeight * 0.01
+            document.documentElement.style.setProperty('--vh', `${vh}px`)
+            
+            // Set height using CSS custom property
+            setHeight('calc(var(--vh, 1vh) * 100)')
+        }
+
+        updateHeight()
+        window.addEventListener('resize', updateHeight)
+        window.addEventListener('orientationchange', updateHeight)
+
+        return () => {
+            window.removeEventListener('resize', updateHeight)
+            window.removeEventListener('orientationchange', updateHeight)
+        }
+    }, [])
+
+    return height
+}
+
+export function useDynamicViewportHeight() {
+    const [dynamicHeight, setDynamicHeight] = useState('100vh')
+
+    useEffect(() => {
+        const updateHeight = () => {
+            // Use dynamic viewport height (dvh) when supported, fallback to custom vh
+            if (CSS.supports('height', '100dvh')) {
+                setDynamicHeight('100dvh')
+            } else {
+                const vh = window.innerHeight * 0.01
+                document.documentElement.style.setProperty('--vh', `${vh}px`)
+                setDynamicHeight('calc(var(--vh, 1vh) * 100)')
+            }
+        }
+
+        updateHeight()
+        window.addEventListener('resize', updateHeight)
+        window.addEventListener('orientationchange', updateHeight)
+
+        return () => {
+            window.removeEventListener('resize', updateHeight)
+            window.removeEventListener('orientationchange', updateHeight)
+        }
+    }, [])
+
+    return dynamicHeight
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -66,6 +66,14 @@ export default {
     			md: 'calc(var(--radius) - 2px)',
     			sm: 'calc(var(--radius) - 4px)'
     		},
+    		height: {
+    			'screen-ios': 'calc(var(--vh, 1vh) * 100)',
+    			'screen-dynamic': '100dvh',
+    		},
+    		minHeight: {
+    			'screen-ios': 'calc(var(--vh, 1vh) * 100)',
+    			'screen-dynamic': '100dvh',
+    		},
     		keyframes: {
     			'accordion-down': {
     				from: {


### PR DESCRIPTION
Adjust sidebar height to correctly fit the device viewport, addressing layout issues caused by iOS 26 Safari padding changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d51ff3d-ecbe-4415-8aa8-f49deffe8fcf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1d51ff3d-ecbe-4415-8aa8-f49deffe8fcf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

