### PR TITLE
Restore nav bar glassmorphism

### DIFF
--- a/components/navbar/user/index.tsx
+++ b/components/navbar/user/index.tsx
@@ -46,7 +46,7 @@ export default function UserNavbar() {
             {hide ? null : (
                 <Sheet open={open} onOpenChange={setOpen}>
                     <header
-                        className={`fixed top-0 left-0 right-0 z-50 transition duration-500 bg-transparent backdrop-blur-sm border-y border-y-white/30 px-4 md:px-0`}
+                        className={`fixed top-0 left-0 right-0 z-50 transition duration-500 glassmorphism mx-4 md:mx-0 mt-2`}
                     >
                         <nav className='py-3 px-2'>
                             <div className='w-full flex justify-between items-center'>


### PR DESCRIPTION
Apply glassmorphism styling to the navbar to revert it to its intended appearance using the existing `glassmorphism` utility class.

---
<a href="https://cursor.com/background-agent?bcId=bc-e36c3ca4-1347-41f8-993f-28e32d235e88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e36c3ca4-1347-41f8-993f-28e32d235e88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

